### PR TITLE
Add machine_infuser_catalysts tag

### DIFF
--- a/src/generated/resources/data/rftoolsbase/tags/items/machine_infuser_catalysts.json
+++ b/src/generated/resources/data/rftoolsbase/tags/items/machine_infuser_catalysts.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:stick"
+  ]
+}

--- a/src/main/java/mcjty/rftoolsbase/datagen/ItemTags.java
+++ b/src/main/java/mcjty/rftoolsbase/datagen/ItemTags.java
@@ -1,5 +1,8 @@
 package mcjty.rftoolsbase.datagen;
 
+import mcjty.rftoolsbase.RFToolsBase;
+import mcjty.rftoolsbase.modules.infuser.MachineInfuserModule;
+import mcjty.rftoolsbase.modules.various.VariousModule;
 import mcjty.rftoolsbase.modules.worldgen.WorldGenModule;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.ItemTagsProvider;
@@ -10,13 +13,15 @@ import net.minecraftforge.common.data.ForgeBlockTagsProvider;
 public class ItemTags extends ItemTagsProvider {
 
     public ItemTags(DataGenerator generator, ExistingFileHelper helper) {
-        super(generator, new ForgeBlockTagsProvider(generator, helper));
+        super(generator, new ForgeBlockTagsProvider(generator, helper), RFToolsBase.MODID, helper);
     }
 
     @Override
     protected void registerTags() {
         getOrCreateBuilder(Tags.Items.ORES)
                 .add(WorldGenModule.DIMENSIONAL_SHARD_END_ITEM.get(), WorldGenModule.DIMENSIONAL_SHARD_NETHER_ITEM.get(), WorldGenModule.DIMENSIONAL_SHARD_OVERWORLD_ITEM.get());
+        getOrCreateBuilder(MachineInfuserModule.MACHINE_INFUSER_CATALYSTS)
+                .add(VariousModule.DIMENSIONALSHARD.get());
     }
 
     @Override

--- a/src/main/java/mcjty/rftoolsbase/modules/infuser/MachineInfuserModule.java
+++ b/src/main/java/mcjty/rftoolsbase/modules/infuser/MachineInfuserModule.java
@@ -3,6 +3,7 @@ package mcjty.rftoolsbase.modules.infuser;
 import mcjty.lib.blocks.BaseBlock;
 import mcjty.lib.container.GenericContainer;
 import mcjty.lib.modules.IModule;
+import mcjty.rftoolsbase.RFToolsBase;
 import mcjty.rftoolsbase.modules.infuser.blocks.MachineInfuserTileEntity;
 import mcjty.rftoolsbase.modules.infuser.client.GuiMachineInfuser;
 import mcjty.rftoolsbase.setup.Config;
@@ -10,7 +11,10 @@ import mcjty.rftoolsbase.setup.Registration;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
+import net.minecraft.tags.ITag;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.tileentity.TileEntityType;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
@@ -23,6 +27,7 @@ public class MachineInfuserModule implements IModule {
     public static final RegistryObject<Item> MACHINE_INFUSER_ITEM = ITEMS.register("machine_infuser", () -> new BlockItem(MACHINE_INFUSER.get(), Registration.createStandardProperties()));
     public static final RegistryObject<TileEntityType<?>> TYPE_MACHINE_INFUSER = TILES.register("machine_infuser", () -> TileEntityType.Builder.create(MachineInfuserTileEntity::new, MACHINE_INFUSER.get()).build(null));
     public static final RegistryObject<ContainerType<GenericContainer>> CONTAINER_MACHINE_INFUSER = CONTAINERS.register("machine_infuser", GenericContainer::createContainerType);
+    public static final ITag.INamedTag<Item> MACHINE_INFUSER_CATALYSTS = ItemTags.createOptional(new ResourceLocation(RFToolsBase.MODID, "machine_infuser_catalysts"));
 
     @Override
     public void init(FMLCommonSetupEvent event) {

--- a/src/main/java/mcjty/rftoolsbase/modules/infuser/blocks/MachineInfuserTileEntity.java
+++ b/src/main/java/mcjty/rftoolsbase/modules/infuser/blocks/MachineInfuserTileEntity.java
@@ -45,7 +45,7 @@ public class MachineInfuserTileEntity extends GenericTileEntity implements ITick
     public static final int SLOT_MACHINEOUTPUT = 1;
 
     public static final Lazy<ContainerFactory> CONTAINER_FACTORY = Lazy.of(() -> new ContainerFactory(2)
-            .slot(specific(new ItemStack(VariousModule.DIMENSIONALSHARD.get())).in(), CONTAINER_CONTAINER, SLOT_SHARDINPUT, 64, 24)
+            .slot(specific(stack -> MachineInfuserModule.MACHINE_INFUSER_CATALYSTS.contains(stack.getItem())).in(), CONTAINER_CONTAINER, SLOT_SHARDINPUT, 64, 24)
             .slot(specific(MachineInfuserTileEntity::isInfusable).in().out(), CONTAINER_CONTAINER, SLOT_MACHINEOUTPUT, 118, 24)
             .playerSlots(10, 70));
 
@@ -94,7 +94,7 @@ public class MachineInfuserTileEntity extends GenericTileEntity implements ITick
         } else {
             ItemStack inputStack = items.getStackInSlot(0);
             ItemStack outputStack = items.getStackInSlot(1);
-            if (!inputStack.isEmpty() && inputStack.getItem() == VariousModule.DIMENSIONALSHARD.get() && isInfusable(outputStack)) {
+            if (!inputStack.isEmpty() && MachineInfuserModule.MACHINE_INFUSER_CATALYSTS.contains(inputStack.getItem()) && isInfusable(outputStack)) {
                 startInfusing();
             }
         }


### PR DESCRIPTION
This PR adds an item tag to allow more than just the dimensional shards from this mod to infuse machines (#34, https://github.com/NillerMedDild/Enigmatica6/issues/1456)