### PR TITLE
Corrected parent/category references in patchouli data

### DIFF
--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/categories/category_basics.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/categories/category_basics.json
@@ -1,7 +1,7 @@
 {
   "name": "Basics",
   "description": "Basic information about RFTools, including worldgen details.",
-  "parent": "category_rftoolsbase",
+  "parent": "rftoolsbase:category_rftoolsbase",
   "icon": "rftoolsbase:dimensionalshard_overworld",
   "sortnum": 10
 }

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/categories/category_machines.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/categories/category_machines.json
@@ -1,7 +1,7 @@
 {
   "name": "Machines",
   "description": "All the machines",
-  "parent": "category_rftoolsbase",
+  "parent": "rftoolsbase:category_rftoolsbase",
   "icon": "rftoolsbase:machine_infuser",
   "sortnum": 30
 }

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/categories/category_tools.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/categories/category_tools.json
@@ -1,7 +1,7 @@
 {
   "name": "Tools",
   "description": "Various tools exist that make your life easier for manipulating and configuring the various tech machines",
-  "parent": "category_rftoolsbase",
+  "parent": "rftoolsbase:category_rftoolsbase",
   "icon": "rftoolsbase:smartwrench",
   "sortnum": 20
 }

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/basics/bugs.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/basics/bugs.json
@@ -1,7 +1,7 @@
 {
   "name": "Found a Bug?",
   "icon": "minecraft:tnt",
-  "category": "category_basics",
+  "category": "rftoolsbase:category_basics",
   "priority": "true",
   "pages": [
     {

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/basics/dimensional_shards.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/basics/dimensional_shards.json
@@ -1,7 +1,7 @@
 {
   "name": "Dimensional Shards",
   "icon": "rftoolsbase:dimensionalshard",
-  "category": "category_basics",
+  "category": "rftoolsbase:category_basics",
   "extra_recipe_mappings":[
     ["rftoolsbase:dimensionalshard",0],
     ["rftoolsbase:dimensionalshard_overworld",0],

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/basics/machine_bases.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/basics/machine_bases.json
@@ -1,7 +1,7 @@
 {
   "name": "Machine Bases",
   "icon": "rftoolsbase:machine_base",
-  "category": "category_basics",
+  "category": "rftoolsbase:category_basics",
   "pages": [
     {
       "type": "text",

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/basics/machine_frames.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/basics/machine_frames.json
@@ -1,7 +1,7 @@
 {
   "name": "Machine Frames",
   "icon": "rftoolsbase:machine_frame",
-  "category": "category_basics",
+  "category": "rftoolsbase:category_basics",
   "pages": [
     {
       "type": "text",

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/basics/modules.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/basics/modules.json
@@ -1,7 +1,7 @@
 {
   "name": "Modules",
   "icon": "rftoolsbase:filter_module",
-  "category": "category_basics",
+  "category": "rftoolsbase:category_basics",
   "pages": [
     {
       "type": "text",

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/machines/information_screen.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/machines/information_screen.json
@@ -1,7 +1,7 @@
 {
   "name": "Information Screen",
   "icon": "rftoolsbase:information_screen",
-  "category": "category_machines",
+  "category": "rftoolsbase:category_machines",
   "pages": [
     {
       "type": "text",

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/machines/infusing.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/machines/infusing.json
@@ -1,7 +1,7 @@
 {
   "name": "Infusing",
   "icon": "rftoolsbase:machine_infuser",
-  "category": "category_machines",
+  "category": "rftoolsbase:category_machines",
   "pages": [
     {
       "type": "text",

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/tools/craftingcard.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/tools/craftingcard.json
@@ -1,7 +1,7 @@
 {
   "name": "Crafting Card",
   "icon": "rftoolsbase:crafting_card",
-  "category": "category_tools",
+  "category": "rftoolsbase:category_tools",
   "pages": [
     {
       "type": "text",

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/tools/filtermodule.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/tools/filtermodule.json
@@ -1,7 +1,7 @@
 {
   "name": "Filter Module",
   "icon": "rftoolsbase:filter_module",
-  "category": "category_tools",
+  "category": "rftoolsbase:category_tools",
   "pages": [
     {
       "type": "text",

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/tools/smartwrench.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/tools/smartwrench.json
@@ -1,7 +1,7 @@
 {
   "name": "Smart Wrench",
   "icon": "rftoolsbase:smartwrench",
-  "category": "category_tools",
+  "category": "rftoolsbase:category_tools",
   "pages": [
     {
       "type": "text",

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/tools/tablet.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/tools/tablet.json
@@ -1,7 +1,7 @@
 {
   "name": "The Tablet",
   "icon": "rftoolsbase:tablet",
-  "category": "category_tools",
+  "category": "rftoolsbase:category_tools",
   "pages": [
     {
       "type": "text",


### PR DESCRIPTION
Fixed various instances of errors like

```
Caused by: java.lang.IllegalArgumentException: `parent` must be fully qualified (domain:name). Hint: Try `rftoolsbase:category_rftoolsbase`
        at vazkii.patchouli.client.book.BookCategory.build(BookCategory.java:156) ~[Patchouli-1.18.1-61_mapped_parchment_2021.12.19-1.18.1.jar
```
