### PR TITLE
Fix syntax for extra_recipe_mappings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ minecraft_version=1.18.2
 forge_version=40.1.51
 
 jei_version=1.18.2:9.7.0.196
-patchouli_version=1.18.2-66
+patchouli_version=1.18.2-71.1
 top_version=1.18-5.1.0-8
 mcjtylib_version=1.18-6.0.15.26
 

--- a/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/basics/dimensional_shards.json
+++ b/src/main/resources/data/rftoolsbase/patchouli_books/manual/en_us/entries/basics/dimensional_shards.json
@@ -2,12 +2,12 @@
   "name": "Dimensional Shards",
   "icon": "rftoolsbase:dimensionalshard",
   "category": "rftoolsbase:category_basics",
-  "extra_recipe_mappings":[
-    ["rftoolsbase:dimensionalshard",0],
-    ["rftoolsbase:dimensionalshard_overworld",0],
-    ["rftoolsbase:dimensionalshard_nether",0],
-    ["rftoolsbase:dimensionalshard_end",0]
-    ],
+  "extra_recipe_mappings": {
+    "rftoolsbase:dimensionalshard": 0,
+    "rftoolsbase:dimensionalshard_overworld": 0,
+    "rftoolsbase:dimensionalshard_nether": 0,
+    "rftoolsbase:dimensionalshard_end": 0
+  },
   "pages": [
     {
       "type": "text",


### PR DESCRIPTION
With the latest version of Patchouli (71.1) this error prevents the book from working:
`Error loading book rftoolsbase:manual, using empty contents and ignoring extensions
com.google.gson.JsonSyntaxException: Expected extra_recipe_mappings to be a JsonObject, was an array ([["r...0]])`

This is due to the following change: https://github.com/VazkiiMods/Patchouli/commit/ff1bf653f11e2eb21802d93ed519b6c80a5e676e

which makes deserialization much stricter. (That change also breaks the books for dependent mods, where now the "name" field is apparently required even if "extend" is specified.)

This PR updates to the new format specified in https://vazkiimods.github.io/Patchouli/docs/reference/entry-json